### PR TITLE
Update docker image name for docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are some methods to use this image.
 
   ```
   my-nginx:
-    image: ubuntu-nginx
+    image: xqdocker/ubuntu-nginx
     volumes:
       - /my/static/content:/data/www
       - /my/nginx.conf:/etc/nginx/nginx.conf


### PR DESCRIPTION
Since no build configuration are included in the YML example, pulling the image will throw 404 since it doesn't exist on the registry global namespace.